### PR TITLE
Testfall für Extended Length in AuditMessages ergänzt

### DIFF
--- a/src/test/java/de/konfidas/ttc/messages/TestAuditLogMessages.java
+++ b/src/test/java/de/konfidas/ttc/messages/TestAuditLogMessages.java
@@ -2,6 +2,7 @@ package de.konfidas.ttc.messages;
 
 import de.konfidas.ttc.exceptions.BadFormatForLogMessageException;
 import de.konfidas.ttc.setup.TestCaseBasisWithCA;
+import org.bouncycastle.asn1.DEROctetString;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Random;
 
 
 import static junit.framework.TestCase.fail;
@@ -23,6 +25,30 @@ public class TestAuditLogMessages extends TestCaseBasisWithCA {
         AuditLogMessageBuilder auditLogMessageBuilder = new AuditLogMessageBuilder();
         byte[] auditMessage = auditLogMessageBuilder.prepare()
                                 .calculateDTBS()
+                                .sign(getClientCertKeyPair().getPrivate())
+                                .build()
+                                .finalizeMessage();
+
+
+        String filename = auditLogMessageBuilder.getFilename();
+
+        AuditLogMessage auditLogMessage = new AuditLogMessage(auditMessage, filename);
+    }
+
+
+
+    @Test
+    public void validAuditLogMessageWithSeAuditDataWithExtendedLength() throws LogMessageBuilder.TestLogMessageCreationError, BadFormatForLogMessageException { ;
+        AuditLogMessageBuilder auditLogMessageBuilder = new AuditLogMessageBuilder();
+         auditLogMessageBuilder.prepare();
+
+
+
+        byte[] longSeAuditData = new byte[2048];
+        new Random().nextBytes(longSeAuditData);
+        DEROctetString seAuditDataAsASN1WithExtendedLength = new DEROctetString(longSeAuditData);
+
+        byte[] auditMessage =    auditLogMessageBuilder.calculateDTBS()
                                 .sign(getClientCertKeyPair().getPrivate())
                                 .build()
                                 .finalizeMessage();


### PR DESCRIPTION
Dieser PR löst #4. Das Feature war schon länger implementiert aber jetzt gibt es auch einen Testfall 