### PR TITLE
refactor TimeLogs into classes

### DIFF
--- a/src/main/java/de/konfidas/ttc/messages/LogMessagePrinter.java
+++ b/src/main/java/de/konfidas/ttc/messages/LogMessagePrinter.java
@@ -36,23 +36,9 @@ public class LogMessagePrinter {
         return_value += String.format("signatureCounter: %d", msg.signatureCounter);
         return_value += System.lineSeparator();
 
-        return_value += String.format("logTimeFormat:: %s", msg.logTimeType);
+        return_value += String.format("logTimeFormat:: %s", msg.getLogTime().getType());
         return_value += System.lineSeparator();
-
-        switch (msg.logTimeType) {
-            case "unixTime":
-                return_value += String.format("logTime: %d", msg.logTimeUnixTime);
-                return_value += System.lineSeparator();
-                break;
-            case "utcTime":
-                return_value += String.format("logTime: %s", msg.logTimeUTC);
-                return_value += System.lineSeparator();
-                break;
-            case "generalizedTime":
-                return_value += String.format("logTime: %s", msg.logTimeGeneralizedTime);
-                return_value += System.lineSeparator();
-                break;
-        }
+        return_value += String.format("logTime: %d", msg.getLogTime().toString());
 
         return_value += String.format("signatureValue:: %s", Hex.encodeHexString(msg.signatureValue));
         return_value += System.lineSeparator();

--- a/src/main/java/de/konfidas/ttc/messages/logtime/GeneralizedLogTime.java
+++ b/src/main/java/de/konfidas/ttc/messages/logtime/GeneralizedLogTime.java
@@ -1,0 +1,19 @@
+package de.konfidas.ttc.messages.logtime;
+
+public class GeneralizedLogTime extends LogTime {
+    String time;
+
+    public GeneralizedLogTime(String time) {
+        this.time = time;
+    }
+
+    @Override
+    public String toString(){
+        return time;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.GENERALIZED;
+    }
+}

--- a/src/main/java/de/konfidas/ttc/messages/logtime/LogTime.java
+++ b/src/main/java/de/konfidas/ttc/messages/logtime/LogTime.java
@@ -1,0 +1,10 @@
+package de.konfidas.ttc.messages.logtime;
+
+public abstract class LogTime{
+
+    public enum Type{
+        UNIX, GENERALIZED, UTC;
+    }
+
+    public abstract Type getType();
+}

--- a/src/main/java/de/konfidas/ttc/messages/logtime/UnixLogTime.java
+++ b/src/main/java/de/konfidas/ttc/messages/logtime/UnixLogTime.java
@@ -1,0 +1,21 @@
+package de.konfidas.ttc.messages.logtime;
+
+public class UnixLogTime extends LogTime {
+    int time;
+    public UnixLogTime(int time) {
+        this.time = time;
+    }
+
+    @Override
+    public String toString(){
+        return Integer.valueOf(time).toString();
+    }
+
+    @Override
+    public Type getType() {
+        return Type.UNIX;
+    }
+    public int getValue(){
+        return time;
+    }
+}

--- a/src/main/java/de/konfidas/ttc/messages/logtime/UtcLogTime.java
+++ b/src/main/java/de/konfidas/ttc/messages/logtime/UtcLogTime.java
@@ -1,0 +1,19 @@
+package de.konfidas.ttc.messages.logtime;
+
+public class UtcLogTime extends LogTime{
+    String time;
+
+    public UtcLogTime(String time) {
+        this.time = time;
+    }
+
+    @Override
+    public String toString(){
+        return time;
+    }
+
+    @Override
+    public Type getType() {
+        return Type.UTC;
+    }
+}

--- a/src/test/java/de/konfidas/ttc/messages/TestParseSystemLog.java
+++ b/src/test/java/de/konfidas/ttc/messages/TestParseSystemLog.java
@@ -2,6 +2,7 @@ package de.konfidas.ttc.messages;
 
 import de.konfidas.ttc.TTC;
 
+import de.konfidas.ttc.messages.logtime.UnixLogTime;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -429,7 +430,8 @@ public class TestParseSystemLog {
         SystemLogMessage msg = new SystemLogMessage(systemLog, "");
 
         assert(msg.getSignatureCounter().equals(BigInteger.valueOf(23)));
-        assert( 1 == msg.getLogTimeUnixTime());
+        assert( msg.getLogTime() instanceof UnixLogTime);
+        assert( 1 == ((UnixLogTime)msg.getLogTime()).getValue() );
     }
 
 


### PR DESCRIPTION
I created classes for the different types of time stamps. The functionality of the classes will have to be extended later on, especially when we start to check the plausibility of sequences of log messages, still, the functionaly should be part of the time stamp, and not part of the printing code or the log message. 

please consider to merge. 