### PR TITLE
 getEncodedLength in LogMessageImplementation verbessert

### DIFF
--- a/src/main/java/de/konfidas/ttc/messages/LogMessageImplementation.java
+++ b/src/main/java/de/konfidas/ttc/messages/LogMessageImplementation.java
@@ -175,12 +175,7 @@ public abstract class LogMessageImplementation implements LogMessage {
             }
 
             byte[] lengthBytesFromElement = Arrays.copyOfRange(elementContent, 2, 2+elementNumberOfLengthBytes); //we need to have 4 bytes for an integer
-            byte[] prependBytes = new byte[4-elementNumberOfLengthBytes];
-
-            ByteBuffer lengthByte = ByteBuffer.wrap(new byte[4]);
-            lengthByte.put(prependBytes);
-            lengthByte.put(lengthBytesFromElement);
-            return lengthByte.getInt(0);
+            return new BigInteger(lengthBytesFromElement).intValue();
         }
     }
 


### PR DESCRIPTION
Geht zurück auf den Kommentar in https://github.com/konfidas/TTC/pull/42#discussion_r619696451