### PR TITLE
make CertificateValidator use BouncyCastle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.31</version>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/java/de/konfidas/ttc/validation/CertificateValidator.java
+++ b/src/main/java/de/konfidas/ttc/validation/CertificateValidator.java
@@ -27,8 +27,9 @@ public class CertificateValidator implements Validator {
         this(trustedCerts,new LinkedList<>());
     }
 
-    public void setEnableRevocationChecking(boolean enableRevocationChecking){
+    public CertificateValidator setEnableRevocationChecking(boolean enableRevocationChecking){
         this.enableRevocationChecking = enableRevocationChecking;
+        return this;
     }
 
     public CertificateValidator(Collection<X509Certificate> trustedCerts,  Collection<CRL> crls){
@@ -63,7 +64,7 @@ public class CertificateValidator implements Validator {
         certs.addAll(intermediateCerts);
 
         CertPath path = cf.generateCertPath(certs);
-        CertPathValidator validator = CertPathValidator.getInstance("PKIX");//NON-NLS
+        CertPathValidator validator = CertPathValidator.getInstance("PKIX", BouncyCastleProvider.PROVIDER_NAME);//NON-NLS
 
         CertStore crlStore = CertStore.getInstance("Collection", new CollectionCertStoreParameters(crls));//NON-NLS
 

--- a/src/main/resources/ttc_de_DE.properties
+++ b/src/main/resources/ttc_de_DE.properties
@@ -2,8 +2,8 @@ de.konfidas.ttc.FileNotExisting = {} existiert nicht.
 de.konfidas.ttc.errorInitializeValidator = Fehler beim Initialisieren des ausgewählten Validators.
 de.konfidas.ttc.errorParsingCommandEitherRootMustBePresentOrOptionChosen = Fehler beim Parsen der Kommandozeile. Es muss entweder ein TrustStore für Root-Zertifikate angegeben werden (Option t) oder auf die Prüfung von Zertifikaten verzichtet werden (Option -o)
 de.konfidas.ttc.exceptions.cause = {0}, Ursache: {1}
-de.konfidas.ttc.exceptions.fileNameToPublicKeyMismatch = Abweichung des Dateinamens vom Public Key. Es wurde {0} gefunden aber {1} erwartet.
-de.konfidas.ttc.exceptions.fileNameToSubjectMismatch = Abweichung des Dateinamens vom Subject. Es wurde {0} gefunden aber {1} erwartet.
+de.konfidas.ttc.exceptions.fileNameToPublicKeyMismatch = Abweichung des Dateinamens vom Public Key. Es wurde %1$s gefunden aber %1$s erwartet.
+de.konfidas.ttc.exceptions.fileNameToSubjectMismatch = Abweichung des Dateinamens vom Subject. Es wurde %1$s gefunden aber %2$s erwartet.
 de.konfidas.ttc.exceptions.validationOfLogMessageFailed = Validierung der LogMessage {0} fehlgeschlagen.
 de.konfidas.ttc.help_errorsOnly = Wenn diese Option gesetzt wird, gibt TTC ausschließlich Informationen  über fehlerhafte Log Messages aus. Informationen über korrekte LogMessages werden unterdrückt.
 de.konfidas.ttc.help_htmlOut = Generiere einen HTML Output.
@@ -31,7 +31,7 @@ de.konfidas.ttc.messages.clientIDInCertifiedDataWrongTag2 = clientID im certifie
 de.konfidas.ttc.messages.extendedLengthLongerThanInt = Der Wert der extended length überschreitet den Wertebereich eines Integer. Dies wird von TTC nicht unterstützt.
 de.konfidas.ttc.messages.failedToIdentifyCertForSerial = Das Zertifikat für die Seriennummer {0} konnte nicht gefunden werden. 
 de.konfidas.ttc.messages.failedToParseMessage = Parsen der LogMessage fehlgeschlagen.
-de.konfidas.ttc.messages.fileNameUnknownTypeOfLogMessages = Der Dateiname {0} passt zu keiner bekannten Log Message.
+de.konfidas.ttc.messages.fileNameUnknownTypeOfLogMessages = Der Dateiname %1$s passt zu keiner bekannten Log Message.
 de.konfidas.ttc.messages.invalidCertifiedDataType = Ungültiges Element certifiedDataType, es wurde id_SE_API_SE_audit_log erwartetet aber {0} gefunden.
 de.konfidas.ttc.messages.invalidCertifiedDataType2 = Invalid Certified Data Type, expected id_SE_API_system_log but found {}
 de.konfidas.ttc.messages.invalidOIDForSignatureAlgorithm = Die OID für signatureAlgorithm lautet {0}. Dies ist keine erlaubte OID
@@ -102,7 +102,7 @@ de.konfidas.ttc.messages.versionFieldOfWrongType = Version muss vom Typ ASN1Inte
 de.konfidas.ttc.messages.wrongVersionNumber = Die Versionsnummer ist nicht 2.
 de.konfidas.ttc.optionGWrongEnding = Der Wert der Option g muss entweder .html oder .htm sein.
 de.konfidas.ttc.reporting.HtmlHeadlineGeneralErrors = <h1 id="generalerrors">Allgemeine Fehler</h1>\n
-de.konfidas.ttc.reporting.clickForCompleteContentOfLogMessage = <button type="button" class="accordion">Hier klicken für den gesamten Inhalt von {0} </button>
+de.konfidas.ttc.reporting.clickForCompleteContentOfLogMessage = <button type="button" class="accordion">Hier klicken für den gesamten Inhalt von %1$s </button>
 de.konfidas.ttc.reporting.errorCreatingHTMLReport = Fehler bei der Erstellung des HTML Reports.
 de.konfidas.ttc.reporting.errorCreatingReport = Fehler bei der Erstellung des Reports.
 de.konfidas.ttc.reporting.headlineValidators = <h1 id="validators">Validators</h1>\n
@@ -111,10 +111,10 @@ de.konfidas.ttc.reporting.htmlMenu = <ul class="nav"> <li><a class="active" href
 de.konfidas.ttc.reporting.htmlReportIntroductionToIssues = <p>Die folgenden, allgemeinen Fehler sind nicht direkt auf eine LogMessage bezogen:</p>
 de.konfidas.ttc.reporting.htmlReportLegitMessagesWereSkipped = (Gültige LogMessages werden in diesem Report nicht ausgegeben.)<br>
 de.konfidas.ttc.reporting.htmlReportNone = <p>Keine</p>
-de.konfidas.ttc.reporting.introductionErrorsHTMLReport = Bei der Prüfung von {0} wurden die folgenden Fehler gefunden
+de.konfidas.ttc.reporting.introductionErrorsHTMLReport = Bei der Prüfung von %1$s wurden die folgenden Fehler gefunden
 de.konfidas.ttc.reporting.introductionGeneralErrors = Die folgenden Probleme wurden gefunden, sind aber nicht direkt auf eine Log Message bezogen: 
 de.konfidas.ttc.reporting.reportCoversTheFollowingArchives = <p> Dieser Report deckt die folgenden Log Message Archive ab:</p>
-de.konfidas.ttc.reporting.introductionNumberOfErrors = <p> Während der Prüfung wurden {0} Fehler gefunden </p>
+de.konfidas.ttc.reporting.introductionNumberOfErrors = <p> Während der Prüfung wurden %1$s Fehler gefunden </p>
 de.konfidas.ttc.reporting.introductionSpecificErrors = Die folgenden Fehler wurden spezifisch für Log Messages gefunden:
 de.konfidas.ttc.reporting.legitMessagesSkipped = (gültige Log Nachrichten werden in diesem Bericht nicht gelistet)
 de.konfidas.ttc.reporting.logMessageIsValid = <li> {} ist gültig </li>
@@ -128,7 +128,7 @@ de.konfidas.ttc.utilities.certificateNotYetValid = Das Zertifikat ist noch nicht
 de.konfidas.ttc.utilities.valueTooLarge = Der Wert von x ist zu groß.
 de.konfidas.ttc.validation.checkingCert = Prüfe das Zertifikat mit Seriennummer {0} auf Korrektheit und prüfe die zugehörige Zertifikatskette.
 de.konfidas.ttc.validation.consistencyErrorForCert = Fehler bei der Konsistenzprüfung des Zertifikats {0}.
-de.konfidas.ttc.validation.errorSignatureCounterIsMissing = Für die TSE {0} fehlt der Signaturzäher {}. Der nächste, gefundene Signaturzähler ist {1}.
+de.konfidas.ttc.validation.errorSignatureCounterIsMissing = Für die TSE %1$s fehlt der Signaturzäher %2$s. Der nächste, gefundene Signaturzähler ist %3$s.
 de.konfidas.ttc.validation.validationOfCertificateFailed = Validierung des Zertifikats {0} fehlgeschlagen.
 de.konfidas.tts.programWillExit = Programm wird nun beendet.
 de.konfidas.ttt.help_rootCA = Trust Anker in Form eines X.509 Zertifikats für die Root-CA


### PR DESCRIPTION
This pull requests fixes the CertificateValidator. It currently does not use BouncyCastle for the PKIX Cert Path Validation, which fails for some EC Curves. 